### PR TITLE
S3 -> RDS LOAD 과정에서 발생하는 duplicate column name error (status) 오류 수정

### DIFF
--- a/dags/load_merge_table_to_redshift_and_rds.py
+++ b/dags/load_merge_table_to_redshift_and_rds.py
@@ -165,6 +165,7 @@ def load_merge_table_to_rds(**context):
         conn = mysql.get_conn()
         cursor = conn.cursor()
         cursor.execute("DELETE FROM production.property")
+        cursor.execute("ALTER TABLE production.property DROP COLUMN status")
         cursor.execute(
             f"""
             LOAD DATA LOCAL INFILE '{file}'


### PR DESCRIPTION
### duplicate column name error (status) 오류 수정
- LOAD 쿼리 실행 이전에 DROP COLUMN을 통해 status 컬럼을 제거한 뒤 LOAD
- 이후 다시 status 컬럼을 생성