### PR TITLE
init: 머신러닝을 활용해 status 예측 후 RDS에 적재하는 DAG

### DIFF
--- a/dags/daily_status_predict_to_rds.py
+++ b/dags/daily_status_predict_to_rds.py
@@ -1,0 +1,173 @@
+import ml_pipeline
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from datetime import datetime
+import pandas as pd
+import os
+import shutil
+import joblib
+
+DEFAULT_DIR = '/opt/airflow/data/ml/'
+
+
+# redshift 에서 전처리 테이블 생성 후 데이터를 가져와 DataFrame으로 변환
+def fetch_transform_train_data(schema, raw_table, preprocessed_table):
+    ml_pipeline.preprocessing_redshift_sold_table(schema, raw_table, preprocessed_table)
+    df = ml_pipeline.fetch_preprocessed_data_from_redshift(schema, preprocessed_table)
+    
+    # 디렉토리가 없을 경우 생성
+    if not os.path.exists(DEFAULT_DIR):
+        os.mkdir(DEFAULT_DIR)
+
+    filepath = os.path.join(DEFAULT_DIR, "train_data.csv")
+    df.to_csv(filepath, encoding="utf-8", index=False)
+
+    return filepath
+    
+
+# 학습 데이터 원핫인코딩, 언더샘플링 진행
+def preprocessing_train_data(**context):
+    filepath = context["task_instance"].xcom_pull(key="return_value", task_ids='fetch_transform_train_data')
+    df = pd.read_csv(filepath)
+
+    df_encoded = ml_pipeline.feature_encoding(df)
+    X_train, y_train = ml_pipeline.perform_undersampling(df_encoded)
+
+    print(f"학습 데이터 개수: {df.shape[0]}")
+
+    filepath_X = os.path.join(DEFAULT_DIR, "X_train_data.csv")
+    filepath_y = os.path.join(DEFAULT_DIR, "y_train_data.csv")
+
+    X_train.to_csv(filepath_X, encoding="utf-8", index=False)
+    y_train.to_csv(filepath_y, encoding="utf-8", index=False)
+
+    return {"X_train":filepath_X, "y_train":filepath_y}
+
+
+# 머신러닝 모델 학습
+def train_ml(**context):
+    filepath = context["task_instance"].xcom_pull(key="return_value", task_ids='preprocessing_train_data')
+
+    # JSON 문자열을 DataFrame으로 변환
+    X_train = pd.read_csv(filepath["X_train"])
+    y_train = pd.read_csv(filepath["y_train"])
+    
+    model = ml_pipeline.train_randomforest(X_train, y_train)
+    
+    filepath_model = os.path.join(DEFAULT_DIR, "model.joblib")
+    joblib.dump(model, filepath_model)
+
+    return filepath_model
+
+
+# RDS table에서 데이터 추출 및 원핫인코딩
+def fetch_preprocessed_property_from_rds(schema, table):
+    df = ml_pipeline.fetch_preprocessed_data_from_rds(schema, table)
+    df_encoded = ml_pipeline.feature_encoding(df)
+
+    filepath = os.path.join(DEFAULT_DIR, "rds_data.csv")
+    df_encoded.to_csv(filepath, encoding="utf-8", index=False)
+
+    return filepath
+
+
+# 머신러닝 모델에서 예측된 status 추출
+def predict_status(**context):
+    filepath_data = context["task_instance"].xcom_pull(key="return_value", task_ids='fetch_preprocessed_property_from_rds')
+    df = pd.read_csv(filepath_data)
+
+    filepath_model = context["task_instance"].xcom_pull(key="return_value", task_ids='train_ml')
+    model = joblib.load(filepath_model)
+
+    predict_df = ml_pipeline.predict_status(df, model)
+
+    filepath = os.path.join(DEFAULT_DIR, "predict_data.csv")
+    predict_df.to_csv(filepath, encoding="utf-8", index=False)
+
+    return filepath
+
+
+# RDS table에 status 값 update
+def update_predicted_status_in_rds(schema, table, **context):
+    filepath = context["task_instance"].xcom_pull(key="return_value", task_ids='predict_status')
+    df = pd.read_csv(filepath)
+    
+    ml_pipeline.update_status_in_rds(df, schema, table)
+
+
+# 다운로드 받은 임시 파일을 삭제
+def clear_directory():
+    for filename in os.listdir(DEFAULT_DIR):
+        file_path = os.path.join(DEFAULT_DIR, filename)
+        try:
+            if os.path.isfile(file_path) or os.path.islink(file_path):
+                os.unlink(file_path)
+            elif os.path.isdir(file_path):
+                shutil.rmtree(file_path)
+        except Exception as e:
+            print(f'Failed to delete {file_path}. Reason: {e}')
+
+
+
+default_args = {
+    'retries': 1,
+}
+
+
+with DAG(
+    dag_id='daily_status_predict_to_rds',
+    start_date=datetime(2024, 7, 1),
+    catchup=False,
+    schedule_interval='@once',
+    default_args=default_args,
+) as dag:
+    fetch_transform_train_data = PythonOperator(
+        task_id='fetch_transform_train_data',
+        python_callable=fetch_transform_train_data,
+        op_kwargs={
+            "schema": "transformed",
+            "raw_table": "property_sold_status",
+            "preprocessed_table": "model_data"
+        }
+    )
+
+    preprocessing_train_data = PythonOperator(
+        task_id='preprocessing_train_data',
+        python_callable=preprocessing_train_data
+    )
+
+    train_ml = PythonOperator(
+        task_id='train_ml',
+        python_callable=train_ml
+    )
+
+    fetch_preprocessed_property_from_rds = PythonOperator(
+        task_id='fetch_preprocessed_property_from_rds',
+        python_callable=fetch_preprocessed_property_from_rds,
+        op_kwargs={
+            "schema": "raw_data",
+            "table": "property"
+        }
+    )
+
+    predict_status = PythonOperator(
+        task_id='predict_status',
+        python_callable=predict_status
+    )
+
+    update_predicted_status_in_rds = PythonOperator(
+        task_id='update_predicted_status_in_rds',
+        python_callable=update_predicted_status_in_rds,
+        op_kwargs={
+            "schema": "raw_data",
+            "table": "property"
+        }
+    )
+
+    clear_directory = PythonOperator(
+        task_id='clear_directory',
+        python_callable=clear_directory
+    )
+
+    fetch_transform_train_data >> preprocessing_train_data >> train_ml >> fetch_preprocessed_property_from_rds >> predict_status >> update_predicted_status_in_rds

--- a/dags/ml_pipeline.py
+++ b/dags/ml_pipeline.py
@@ -1,0 +1,281 @@
+import pandas as pd
+from sklearn.preprocessing import OneHotEncoder
+from imblearn.under_sampling import RandomUnderSampler
+from sklearn.ensemble import RandomForestClassifier
+from airflow.providers.postgres.hooks.postgres import PostgresHook
+from airflow.providers.mysql.hooks.mysql import MySqlHook
+
+
+
+def get_Redshift_connection(autocommit=True):
+    hook = PostgresHook(postgres_conn_id='redshift_conn')  # redshift_dev_db
+    conn = hook.get_conn()
+    conn.autocommit = autocommit
+    return conn.cursor()
+
+
+def get_RDS_connection(autocommit=True):
+    hook = MySqlHook(mysql_conn_id='rds_conn', local_infile=True)
+    conn = hook.get_conn()
+    conn.autocommit = autocommit
+    return conn.cursor()
+
+
+# redshift 에서 sold 테이블에 대해 전처리 후 전처리 테이블 생성
+def preprocessing_redshift_sold_table(schema, raw_table, preprocessed_table): # transformed model_data property_sold_status
+    try:
+        cursor = get_Redshift_connection()  
+
+        cursor.execute("BEGIN;")
+        sql = f"""
+            DROP TABLE IF EXISTS {schema}.{preprocessed_table};
+
+            CREATE TABLE {schema}.{preprocessed_table} AS (
+                SELECT room_id,
+                    CASE
+                        WHEN floor LIKE '%옥탑%' THEN '옥탑'
+                        WHEN floor LIKE '%반지%' THEN '반지하'
+                        WHEN floor LIKE '%저%' THEN '기타'
+                        WHEN floor LIKE '%중%' THEN '기타'
+                        WHEN floor LIKE '%고%' THEN '기타'
+                        WHEN floor LIKE '%층' THEN
+                            CASE
+                                WHEN CAST(REPLACE(floor, '층', '') AS INTEGER) BETWEEN 1 AND 2 THEN '저'
+                                WHEN CAST(REPLACE(floor, '층', '') AS INTEGER) BETWEEN 3 AND 14 THEN '중'
+                                WHEN CAST(REPLACE(floor, '층', '') AS INTEGER) >= 15 THEN '고'
+                            END
+                        WHEN floor NOT LIKE '%층' THEN
+                            CASE
+                                WHEN CAST(floor AS INTEGER) BETWEEN 1 AND 2 THEN '저'
+                                WHEN CAST(floor AS INTEGER) BETWEEN 3 AND 14 THEN '중'
+                                WHEN CAST(floor AS INTEGER) >= 15 THEN '고'
+                            END
+                        ELSE '기타'
+                    END AS floor_level,
+                    area,
+                    deposit,
+                    rent,
+                    maintenance_fee,
+                    CASE
+                        WHEN address LIKE '%강남구%' THEN '강남구'
+                        WHEN address LIKE '%강동구%' THEN '강동구'
+                        WHEN address LIKE '%강북구%' THEN '강북구'
+                        WHEN address LIKE '%강서구%' THEN '강서구'
+                        WHEN address LIKE '%관악구%' THEN '관악구'
+                        WHEN address LIKE '%광진구%' THEN '광진구'
+                        WHEN address LIKE '%구로구%' THEN '구로구'
+                        WHEN address LIKE '%금천구%' THEN '금천구'
+                        WHEN address LIKE '%노원구%' THEN '노원구'
+                        WHEN address LIKE '%도봉구%' THEN '도봉구'
+                        WHEN address LIKE '%동대문구%' THEN '동대문구'
+                        WHEN address LIKE '%동작구%' THEN '동작구'
+                        WHEN address LIKE '%마포구%' THEN '마포구'
+                        WHEN address LIKE '%서대문구%' THEN '서대문구'
+                        WHEN address LIKE '%서초구%' THEN '서초구'
+                        WHEN address LIKE '%성동구%' THEN '성동구'
+                        WHEN address LIKE '%성북구%' THEN '성북구'
+                        WHEN address LIKE '%송파구%' THEN '송파구'
+                        WHEN address LIKE '%양천구%' THEN '양천구'
+                        WHEN address LIKE '%영등포구%' THEN '영등포구'
+                        WHEN address LIKE '%용산구%' THEN '용산구'
+                        WHEN address LIKE '%은평구%' THEN '은평구'
+                        WHEN address LIKE '%종로구%' THEN '종로구'
+                        WHEN address LIKE '%중구%' THEN '중구'
+                        WHEN address LIKE '%중랑구%' THEN '중랑구'
+                        ELSE '기타'
+                    END AS district,
+                    CAST(
+                    (CASE WHEN subway_count >= 1 THEN 1 ELSE 0 END +
+                    CASE WHEN store_count >= 1 THEN 1 ELSE 0 END +
+                    CASE WHEN cafe_count >= 1 THEN 1 ELSE 0 END +
+                    CASE WHEN market_count >= 1 THEN 1 ELSE 0 END +
+                    CASE WHEN restaurant_count >= 1 THEN 1 ELSE 0 END +
+                    CASE WHEN hospital_count >= 1 THEN 1 ELSE 0 END)
+                    AS SMALLINT) AS facility_count,
+                    status
+                FROM {schema}.{raw_table}
+                WHERE district <> '기타' AND floor_level <> '기타'
+            );
+            """
+        cursor.execute(sql)
+        cursor.execute("COMMIT;") 
+
+    except Exception as error:
+        print(error)
+        print("ROLLBACK")
+        cursor.execute("ROLLBACK;")
+        raise
+    
+    finally:
+        cursor.close()
+
+
+# 전처리 테이블에서 데이터를 가져와 데이터프레임 형태로 return
+def fetch_preprocessed_data_from_redshift(schema, preprocessed_table):
+    cursor = get_Redshift_connection()  
+
+    query = f"SELECT * FROM {schema}.{preprocessed_table};"
+    cursor.execute(query)
+
+    records = cursor.fetchall()
+    
+    cursor.close()
+
+    columns = ["room_id", "floor_level", "area", "deposit", "rent", "maintenance_fee", "district", "facility_count", "status"]
+    df = pd.DataFrame(records, columns=columns)
+
+    return df
+
+
+# 카테고리형 변수 인코딩
+def feature_encoding(df):
+    # One-Hot Encoding을 위한 인코더 설정
+    one_hot_encoder = OneHotEncoder(sparse_output=False, drop='if_binary')
+    
+    # 'floor_level'과 'district'을 한 번에 인코딩
+    encoded_features = one_hot_encoder.fit_transform(df[['floor_level', 'district']])
+    
+    # 인코딩된 데이터프레임 생성
+    df_encoded = pd.DataFrame(encoded_features, columns=one_hot_encoder.get_feature_names_out())
+    
+    # 원래 데이터프레임에서 인코딩할 컬럼 제거
+    df_encoded = pd.concat([df.drop(columns=['floor_level', 'district']), df_encoded], axis=1)
+
+    return df_encoded
+
+
+
+# 판매완료, 미판매 데이터 개수를 맞추기 위한 랜덤 언더샘플링
+def perform_undersampling(df):
+    X = df.drop(columns=['room_id', 'status'])
+    y = df['status']
+
+    rus = RandomUnderSampler(sampling_strategy='auto', random_state=42)
+    X_resampled, y_resampled = rus.fit_resample(X, y)
+
+    return X_resampled, y_resampled
+
+
+# random forest 모델 학습
+def train_randomforest(X, y):
+    clf = RandomForestClassifier()
+    clf.fit(X, y)
+
+    return clf
+
+
+# RDS에서 데이터를 가져오면서 전처리 작업
+def fetch_preprocessed_data_from_rds(schema, table): # taw_data.property
+    cursor = get_RDS_connection()  
+
+    query = f"""
+            SELECT room_id,
+                CASE
+                    WHEN floor LIKE '%옥탑%' THEN '옥탑'
+                    WHEN floor LIKE '%반지%' THEN '반지하'
+                    WHEN floor LIKE '%저%' THEN '기타'
+                    WHEN floor LIKE '%중%' THEN '기타'
+                    WHEN floor LIKE '%고%' THEN '기타'
+                    WHEN floor LIKE '%층' THEN
+                        CASE
+                            WHEN CAST(REPLACE(floor, '층', '') AS INTEGER) BETWEEN 1 AND 2 THEN '저'
+                            WHEN CAST(REPLACE(floor, '층', '') AS INTEGER) BETWEEN 3 AND 14 THEN '중'
+                            WHEN CAST(REPLACE(floor, '층', '') AS INTEGER) >= 15 THEN '고'
+                        END
+                    WHEN floor NOT LIKE '%층' THEN
+                        CASE
+                            WHEN CAST(floor AS INTEGER) BETWEEN 1 AND 2 THEN '저'
+                            WHEN CAST(floor AS INTEGER) BETWEEN 3 AND 14 THEN '중'
+                            WHEN CAST(floor AS INTEGER) >= 15 THEN '고'
+                        END
+                    ELSE '기타'
+                END AS floor_level,
+                area,
+                deposit,
+                rent,
+                maintenance_fee,
+                CASE
+                    WHEN address LIKE '%강남구%' THEN '강남구'
+                    WHEN address LIKE '%강동구%' THEN '강동구'
+                    WHEN address LIKE '%강북구%' THEN '강북구'
+                    WHEN address LIKE '%강서구%' THEN '강서구'
+                    WHEN address LIKE '%관악구%' THEN '관악구'
+                    WHEN address LIKE '%광진구%' THEN '광진구'
+                    WHEN address LIKE '%구로구%' THEN '구로구'
+                    WHEN address LIKE '%금천구%' THEN '금천구'
+                    WHEN address LIKE '%노원구%' THEN '노원구'
+                    WHEN address LIKE '%도봉구%' THEN '도봉구'
+                    WHEN address LIKE '%동대문구%' THEN '동대문구'
+                    WHEN address LIKE '%동작구%' THEN '동작구'
+                    WHEN address LIKE '%마포구%' THEN '마포구'
+                    WHEN address LIKE '%서대문구%' THEN '서대문구'
+                    WHEN address LIKE '%서초구%' THEN '서초구'
+                    WHEN address LIKE '%성동구%' THEN '성동구'
+                    WHEN address LIKE '%성북구%' THEN '성북구'
+                    WHEN address LIKE '%송파구%' THEN '송파구'
+                    WHEN address LIKE '%양천구%' THEN '양천구'
+                    WHEN address LIKE '%영등포구%' THEN '영등포구'
+                    WHEN address LIKE '%용산구%' THEN '용산구'
+                    WHEN address LIKE '%은평구%' THEN '은평구'
+                    WHEN address LIKE '%종로구%' THEN '종로구'
+                    WHEN address LIKE '%중구%' THEN '중구'
+                    WHEN address LIKE '%중랑구%' THEN '중랑구'
+                    ELSE '기타'
+                END AS district,
+                CAST(
+                    (CASE WHEN subway_count >= 1 THEN 1 ELSE 0 END +
+                    CASE WHEN store_count >= 1 THEN 1 ELSE 0 END +
+                    CASE WHEN cafe_count >= 1 THEN 1 ELSE 0 END +
+                    CASE WHEN market_count >= 1 THEN 1 ELSE 0 END +
+                    CASE WHEN restaurant_count >= 1 THEN 1 ELSE 0 END +
+                    CASE WHEN hospital_count >= 1 THEN 1 ELSE 0 END)
+                AS SMALLINT) AS facility_count
+            FROM {schema}.{table}
+            WHERE district <> '기타' AND floor_level <> '기타'
+        );
+    """
+    cursor.execute(query)
+
+    records = cursor.fetchall()
+    
+    cursor.close()
+
+    columns = ["room_id", "floor_level", "area", "deposit", "rent", "maintenance_fee", "district", "facility_count", "status"]
+    df = pd.DataFrame(records, columns=columns)
+
+    return df
+
+
+def predict_status(df, model):
+    X = df.drop(columns=['room_id', 'status'])
+    predictions = model.predict(X)
+    df["status"] = predictions
+
+    return df
+
+
+def update_status_in_rds(df, schema, table):
+    update_query = f"""
+            UPDATE {schema}.{table}
+            SET status = %s
+            WHERE room_id = %s
+        """
+    
+    try:
+        cursor = get_RDS_connection()  
+
+        cursor.execute("BEGIN;")
+
+        for row in df.iterrows():
+            cursor.execute(update_query, (row["room_id"], row["status"]))
+        
+        cursor.execute("COMMIT;") 
+
+    except Exception as error:
+        print(error)
+        print("ROLLBACK")
+        cursor.execute("ROLLBACK;")
+        raise
+    
+    finally:
+        cursor.close()


### PR DESCRIPTION
# PR 내용
- Redshift에 적재된 데이터로 머신러닝 모델을 학습 후, RDS의 매물 데이터의 판매 여부를 예측해 적재하는 DAG
- DAG 정의 파일과 로직이 정의된 파일을 별도로 생성
    - `daily_status_predict_to_rds.py` : DAG 정의 파일
    - `ml_pipeline.py` : 로직 정의 파일
- 매일 실행하는 DAG이지만, 테스트 과정 중으로 명확한 DAG 실행 시간은 설정하지 않음.
    - 앞서 데이터 수집, 전처리, 병합 등의 선행되어야 하는 DAG가 있어 다른 DAG의 실행 시간과 테스트 과정 중 실행 시간을 측정하여 실행 시간을 설정할 예정
- 모델 학습 task(`train_ml`) 까지 로컬 환경에서 테스트를 완료한 상황
    - airflow 서버에 DAG 코드를 적재한 후 한 번 더 테스트하며 디버깅하는 과정 필요
- DataFrame, 머신러닝 모델 객체같이 복잡한 형태는 xcom을 활용하기 어려워 클레임 체크 패턴(Claim Check Pattern) 방식을 활용. 
    - airflow 서버와 연결된 volumn에 데이터를 임시로 저장하며 task 사이에 데이터를 전달할 수 있도록 구현
    - DAG가 끝나갈 때 디렉토리 안에 저장된 모든 데이터를 삭제
- 이 commit에서는 실수로 `clear_directory` task를 task dependencies에 추가하지 않았는데, 이후 이 부분을 수정해 commit하였음 ([5ffff11](https://github.com/lv1turtle/Studio-Recommendation-Service/commit/5ffff1135ec31229f75739721f2761ecc0e84022))

# DAG 동작 원리

1. redshift의 `transformed.property_sold_status` 테이블로부터 전처리된 테이블 `transformed.model_data` 를 생성한다
2. `transformed.model_data` 로부터 데이터를 가져와 원핫인코딩, 판매 여부(status)에 따라 랜덤 언더 샘플링을 진행한다
    - 원핫인코딩(One-hot encoding)
        - 머신러닝 모델이 데이터를 학습시킬 때 정수형이 아닌 카테고리 형태의 컬럼(district, floor_level)은 사용할 수 없고, 이런 컬럼을 정수형으로 바꿔주어야 한다
        - 이때 하나의 컬럼에 있던 값을 여러 컬럼으로 분산시켜 주는 것을 원핫인코딩이라고 한다
        
        ![one-hot encoding](https://miro.medium.com/v2/resize:fit:1200/1*ggtP4a5YaRx6l09KQaYOnw.png)
        
    - 랜덤 언더 샘플링
        - `property_sold_status` 테이블에 있는 데이터는 status 값에 따라 개수의 차이가 존재한다.
        - y 값의 분포가 편향된 경우을 데이터 불균형이라고 하며, 모델 학습 시에 악영향을 끼칠 수 있어 언더 샘플링을 진행한다
        - 언더 샘플링이란, 개수가 적은 값에 다수인 값의 데이터 개수를 맞추는 것이다. 즉, 다수인 값의 모든 데이터를 사용하는 것이 아니고 일부를 쳐내는 것이다
        - 언더 샘플링을 진행하면서 샘플링하는 데이터를 랜덤으로 결정하도록 하였다
3. scikit learn 패키지를 사용해 Random forest 모델을 학습시킨다
    - 우리는 분석 목적이 아니므로, train / test set을 나누지 않고 모든 데이터를 학습 시킨다
4. production DB, 즉 RDS의 `raw_data.property` 테이블에서 데이터를 가져온다 
    - 이때 모델에 맞는 형태로 데이터를 입력하기 위해 앞서 진행한 전처리, 원핫인코딩 진행
5. 매물 데이터를 모델에 입력해 예측된 status 값을 RDS에 update한다